### PR TITLE
fix: Implement dynamic blog listing on homepage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │       ├── index.astro     # ルートページ
 │       ├── about.astro     # Aboutページ（Astroの動的機能を活用）
 │       └── posts/          # ブログ投稿（マークダウン）
-│           └── first-development-journey.md
+│           ├── first-development-journey.md      # 初回開発記録
+│           └── astro-dynamic-features.md         # Astro動的機能記録
 ├── astro.config.mjs # Astro設定ファイル
 ├── tsconfig.json    # TypeScript設定（astro/tsconfigs/strictを継承）
 └── package.json     # プロジェクト依存関係
@@ -131,9 +132,45 @@ tags: ["tag1", "tag2", "tag3"]
 
 ### 既存の投稿
 
+- **Astro動的機能**: `/posts/astro-dynamic-features` - Astroの動的機能を活用したAboutページ改善記録
 - **開発記録**: `/posts/first-development-journey` - プロジェクトの開発プロセスをまとめた最初の投稿
 
 ## Astroの動的機能活用
+
+### トップページの動的ブログリスト機能
+
+`src/pages/index.astro` では以下の動的機能を実装：
+
+- **自動投稿取得**: `import.meta.glob()` を使用してブログ投稿を自動取得
+- **日付ソート**: 公開日による降順ソート（最新投稿が上位表示）
+- **動的リスト表示**: 投稿の追加で自動的にトップページに反映
+- **メタデータ表示**: タイトル、説明、公開日、タグの自動表示
+
+#### 実装パターン
+```astro
+---
+// すべてのブログ投稿を取得
+const posts = import.meta.glob('./posts/*.md', { eager: true });
+const allPosts = Object.values(posts);
+
+// 公開日で降順ソート（最新が上位）
+const sortedPosts = allPosts.sort((a, b) => {
+  return new Date(b.frontmatter.pubDate).getTime() - new Date(a.frontmatter.pubDate).getTime();
+});
+---
+
+<!-- 動的投稿リスト -->
+{sortedPosts.map((post) => (
+  <article>
+    <h3><a href={post.url}>{post.frontmatter.title}</a></h3>
+    <p>{post.frontmatter.description}</p>
+    <!-- タグ表示 -->
+    {post.frontmatter.tags.map((tag) => (
+      <span class="tag">{tag}</span>
+    ))}
+  </article>
+))}
+```
 
 ### Aboutページの実装例
 `src/pages/about.astro` では以下のAstroの動的機能を活用：

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,14 @@
 ---
 import Layout from '../layouts/Layout.astro';
+
+// すべてのブログ投稿を取得
+const posts = import.meta.glob('./posts/*.md', { eager: true });
+const allPosts = Object.values(posts);
+
+// 公開日で降順ソート（最新が上位）
+const sortedPosts = allPosts.sort((a, b) => {
+  return new Date(b.frontmatter.pubDate).getTime() - new Date(a.frontmatter.pubDate).getTime();
+});
 ---
 
 <Layout title="Engineer Journey">
@@ -9,11 +18,26 @@ import Layout from '../layouts/Layout.astro';
 		
 		<section>
 			<h2>最新の投稿</h2>
-			<article>
-				<h3><a href="/posts/first-development-journey">Engineer Journey ブログサイト開発記録</a></h3>
-				<p>Astroを使用したブログサイトの開発プロセスと学んだことをまとめた最初の投稿</p>
-				<time datetime="2025-06-27">2025年6月27日</time>
-			</article>
+			{sortedPosts.map((post) => (
+				<article>
+					<h3><a href={post.url}>{post.frontmatter.title}</a></h3>
+					<p>{post.frontmatter.description}</p>
+					<div class="post-meta">
+						<time datetime={post.frontmatter.pubDate}>
+							{new Date(post.frontmatter.pubDate).toLocaleDateString('ja-JP', {
+								year: 'numeric',
+								month: 'long',
+								day: 'numeric'
+							})}
+						</time>
+						<div class="tags">
+							{post.frontmatter.tags.map((tag) => (
+								<span class="tag">{tag}</span>
+							))}
+						</div>
+					</div>
+				</article>
+			))}
 		</section>
 		
 		<nav>
@@ -70,9 +94,30 @@ import Layout from '../layouts/Layout.astro';
 		color: #666;
 	}
 	
+	.post-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 1rem;
+	}
+	
 	time {
 		font-size: 0.9rem;
 		color: #888;
+	}
+	
+	.tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+	
+	.tag {
+		background-color: #f0f0f0;
+		color: #555;
+		padding: 0.2rem 0.5rem;
+		border-radius: 0.3rem;
+		font-size: 0.8rem;
 	}
 	
 	nav {


### PR DESCRIPTION
## Summary
- Fixed issue where second blog post was not displayed on homepage
- Replaced hardcoded blog posts with dynamic import.meta.glob() implementation
- Added automatic sorting by publication date (newest first)
- Implemented dynamic post metadata display with tags

## Changes Made
- **src/pages/index.astro**: Implemented dynamic blog listing with import.meta.glob()
- **CLAUDE.md**: Updated documentation with new dynamic features and project structure

## Technical Details
- Used `import.meta.glob()` to automatically discover all blog posts
- Implemented date-based sorting (newest posts appear first)
- Added responsive tag styling and improved metadata display
- Ensured new blog posts automatically appear on homepage without manual updates

## Test Plan
- [x] Build passes without errors
- [x] Homepage displays both blog posts in correct order (newest first)
- [x] All post metadata (title, description, date, tags) displays correctly
- [x] Links to individual blog posts work properly
- [x] Responsive design maintained

🤖 Generated with [Claude Code](https://claude.ai/code)