### PR TITLE
ブログ記事レイアウトをモダンなカード型デザインに刷新

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -16,60 +16,67 @@ const readingTime = calculateReadingTime(content);
 ---
 
 <Layout title={frontmatter.title}>
-	<article class="max-w-4xl mx-auto px-6 py-8">
-		<header class="mb-8 pb-6 border-b border-gray-200">
-			<h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4 leading-tight">{frontmatter.title}</h1>
-			<div class="flex flex-wrap items-center gap-4 text-sm text-gray-600 mb-4">
-				<time datetime={frontmatter.pubDate} class="flex items-center gap-1">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-					</svg>
-					{new Date(frontmatter.pubDate).toLocaleDateString('ja-JP', {
-						year: 'numeric',
-						month: 'long',
-						day: 'numeric'
-					})}
-				</time>
-				<span class="flex items-center gap-1">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-					</svg>
-					{frontmatter.author}
-				</span>
-				<span class="flex items-center gap-1">
-					<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-					</svg>
-					約{readingTime}分で読めます
-				</span>
-			</div>
-			{frontmatter.description && (
-				<p class="text-lg text-gray-700 italic mb-4 leading-relaxed">{frontmatter.description}</p>
-			)}
-			{frontmatter.tags && (
-				<div class="flex flex-wrap gap-2">
-					{frontmatter.tags.map((tag) => (
-						<span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 hover:bg-blue-200 transition-colors">
-							#{tag}
-						</span>
-					))}
+	<div class="min-h-screen bg-gray-50">
+		<!-- ヘッダーセクション - モダンなグラデーション -->
+		<header class="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
+			<div class="max-w-4xl mx-auto px-6 py-12">
+				<div class="flex items-center gap-2 mb-4">
+					<a href="/" class="inline-flex items-center text-blue-100 hover:text-white transition-colors text-sm font-medium">
+						<svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+						</svg>
+						ホームへ戻る
+					</a>
 				</div>
-			)}
+				<h1 class="text-3xl md:text-4xl font-bold mb-4 leading-tight">{frontmatter.title}</h1>
+				{frontmatter.description && (
+					<p class="text-xl opacity-90 mb-6 leading-relaxed">{frontmatter.description}</p>
+				)}
+				<div class="flex flex-wrap items-center gap-4 text-sm opacity-90">
+					<time datetime={frontmatter.pubDate} class="flex items-center gap-1">
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 002 2z" />
+						</svg>
+						{new Date(frontmatter.pubDate).toLocaleDateString('ja-JP', {
+							year: 'numeric',
+							month: 'long',
+							day: 'numeric'
+						})}
+					</time>
+					<span class="flex items-center gap-1">
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+						</svg>
+						{frontmatter.author}
+					</span>
+					<span class="flex items-center gap-1">
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+						</svg>
+						約{readingTime}分で読めます
+					</span>
+				</div>
+				{frontmatter.tags && (
+					<div class="flex flex-wrap gap-2 mt-4">
+						{frontmatter.tags.map((tag) => (
+							<span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/20 text-white hover:bg-white/30 transition-colors">
+								#{tag}
+							</span>
+						))}
+					</div>
+				)}
+			</div>
 		</header>
-		
-		<main class="prose prose-xl prose-gray max-w-3xl mx-auto leading-relaxed mb-12 prose-headings:scroll-mt-8 prose-h1:hidden prose-h2:text-2xl prose-h2:font-semibold prose-h2:mt-12 prose-h2:mb-4 prose-h2:border-b prose-h2:border-gray-200 prose-h2:pb-2 prose-h3:text-xl prose-h3:font-medium prose-h3:mt-8 prose-h3:mb-3 prose-p:mb-6 prose-p:leading-relaxed prose-li:mb-2 prose-code:bg-gray-100 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-sm prose-code:font-mono prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:rounded-lg prose-pre:p-4 prose-pre:overflow-x-auto prose-blockquote:border-l-4 prose-blockquote:border-blue-500 prose-blockquote:bg-blue-50 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:my-6">
-			<slot />
+
+		<!-- メインコンテンツ - カード型デザイン -->
+		<main class="max-w-4xl mx-auto px-6 py-8">
+			<article class="bg-white rounded-xl shadow-md overflow-hidden">
+				<div class="prose prose-xl prose-gray max-w-none px-8 py-8 leading-relaxed prose-headings:scroll-mt-8 prose-h1:hidden prose-h2:text-2xl prose-h2:font-semibold prose-h2:mt-12 prose-h2:mb-4 prose-h2:border-b prose-h2:border-gray-200 prose-h2:pb-2 prose-h3:text-xl prose-h3:font-medium prose-h3:mt-8 prose-h3:mb-3 prose-p:mb-6 prose-p:leading-relaxed prose-li:mb-2 prose-code:bg-gray-100 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:text-sm prose-code:font-mono prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:rounded-lg prose-pre:p-4 prose-pre:overflow-x-auto prose-blockquote:border-l-4 prose-blockquote:border-blue-500 prose-blockquote:bg-blue-50 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:my-6">
+					<slot />
+				</div>
+			</article>
 		</main>
-		
-		<footer class="pt-6 border-t border-gray-200">
-			<a href="/" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 transition-colors font-medium">
-				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-				</svg>
-				ホームへ戻る
-			</a>
-		</footer>
-	</article>
+	</div>
 </Layout>
 
 <script>


### PR DESCRIPTION
## Summary
• indexページと同じモダンなグラデーションヘッダーを記事ページに適用
• 記事コンテンツを白いカードでラップしてindexページと統一感を演出
• 背景をグレーに変更してカードが際立つデザインに改善
• タグのスタイリングを半透明白背景に変更してヘッダーに統合

## 主な変更点
- **ヘッダー強化**: 青紫グラデーション背景で視覚的インパクト向上
- **カード型レイアウト**: 記事コンテンツを白いカード（rounded-xl shadow-md）でラップ
- **統一感のあるデザイン**: indexページと同じデザインパターンを適用
- **レスポンシブ対応**: モバイル・デスクトップ両対応を維持

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] 記事ページの表示が正常であることを確認
- [x] レスポンシブデザインが機能することを確認
- [x] 既存の機能（コピーボタン、タグ表示等）が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)