### PR TITLE
fix: スマホ表示対応でミニマルデザインを改善

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -55,4 +55,29 @@ const { currentPath } = Astro.props;
 		height: 1px;
 		background-color: var(--color-black);
 	}
+
+	/* Mobile Navigation */
+	@media (max-width: 768px) {
+		nav {
+			padding: 1.5rem 0 1rem;
+		}
+		
+		nav div {
+			flex-direction: column;
+			gap: 1rem;
+			align-items: flex-start;
+		}
+		
+		nav a {
+			padding: 0.5rem 0;
+			min-height: 44px;
+			display: flex;
+			align-items: center;
+			width: 100%;
+		}
+		
+		nav a.active::after {
+			bottom: 0;
+		}
+	}
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,6 +128,14 @@ const { title, currentPath } = Astro.props;
 		.container-wide {
 			padding: 0 1.5rem;
 		}
+
+		/* Smart heading sizes for mobile */
+		h1 { font-size: 1.75rem; }
+		h2 { font-size: 1.5rem; }
+		h3 { font-size: 1.25rem; }
+		h4 { font-size: 1.125rem; }
+		h5 { font-size: 1rem; }
+		h6 { font-size: 0.875rem; }
 	}
 
 	/* Main content flex grow */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,7 @@ const { title, currentPath } = Astro.props;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="description" content="Astro description" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
@@ -53,7 +53,7 @@ const { title, currentPath } = Astro.props;
 		line-height: 1.7;
 		color: var(--color-gray-900);
 		background-color: var(--color-white);
-		font-size: 18px;
+		font-size: clamp(16px, 4vw, 18px);
 	}
 
 	body {
@@ -108,15 +108,26 @@ const { title, currentPath } = Astro.props;
 
 	/* Content Container */
 	.container {
-		max-width: 65ch;
+		max-width: min(65ch, 100vw - 2rem);
 		margin: 0 auto;
 		padding: 0 1rem;
 	}
 
 	.container-wide {
-		max-width: 80ch;
+		max-width: min(80ch, 100vw - 2rem);
 		margin: 0 auto;
 		padding: 0 1rem;
+	}
+
+	/* Mobile Responsive */
+	@media (max-width: 768px) {
+		.container {
+			padding: 0 1.5rem;
+		}
+		
+		.container-wide {
+			padding: 0 1.5rem;
+		}
 	}
 
 	/* Main content flex grow */

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -180,4 +180,43 @@ const readingTime = calculateReadingTime(content);
 		background: var(--color-gray-200);
 		color: var(--color-black);
 	}
+
+	/* Mobile Post Layout */
+	@media (max-width: 768px) {
+		article {
+			padding: 1.5rem 0;
+		}
+		
+		header {
+			padding-bottom: 1.5rem;
+			margin-bottom: 2rem;
+		}
+		
+		.meta {
+			flex-direction: column;
+			gap: 0.5rem;
+			align-items: flex-start;
+		}
+		
+		.tags {
+			margin-top: 0.5rem;
+		}
+		
+		.article-footer {
+			padding-top: 2rem;
+			margin-top: 2rem;
+		}
+		
+		pre button {
+			position: static;
+			margin-top: 0.5rem;
+			align-self: flex-end;
+		}
+		
+		pre {
+			position: relative;
+			display: flex;
+			flex-direction: column;
+		}
+	}
 </style>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -191,6 +191,11 @@ const readingTime = calculateReadingTime(content);
 			padding-bottom: 1.5rem;
 			margin-bottom: 2rem;
 		}
+
+		header h1 {
+			font-size: 1.5rem;
+			line-height: 1.3;
+		}
 		
 		.meta {
 			flex-direction: column;


### PR DESCRIPTION
## Summary
- スマホでの文字サイズと余白問題を解決し、ミニマルデザイン思想に沿った改善を実装
- viewport設定修正、レスポンシブレイアウト、見出しサイズ最適化を実施

## 主な変更内容
- **Layout.astro**: viewport設定修正、フルードタイポグラフィ、スマホ対応見出しサイズ
- **Navigation.astro**: スマホ対応縦並びレイアウト、タップエリア44px確保
- **MarkdownPostLayout.astro**: メタ情報縦並び対応、記事タイトルサイズ調整

## 改善効果
- スマホでの文字サイズが適切に（16px-18px可変）
- 左右余白を十分に確保（1.5rem）
- 見出しサイズを控えめに調整してミニマルデザインを強化
- 768px以下の単一ブレークポイントでシンプル対応

## Test plan
- [x] npm run build でエラーなし
- [x] 既存の投稿ページが正常表示
- [x] ナビゲーションのスマホ対応確認
- [x] ミニマルデザイン原則の維持

🤖 Generated with [Claude Code](https://claude.ai/code)