### PR TITLE
fix: 全ブログ投稿に時刻情報を追加して正確なソート順序を実現

### DIFF
--- a/src/pages/posts/astro-dynamic-features.md
+++ b/src/pages/posts/astro-dynamic-features.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'Astroの動的機能でAboutページを進化させた話'
-pubDate: 2025-06-27
+pubDate: 2025-06-27T17:00:00
 description: 'Astroチュートリアルを参考に、静的なAboutページを動的でインタラクティブなページに改善した開発記録'
 author: 'エンジニア'
 tags: ["Astro", "JavaScript", "フロントエンド", "動的レンダリング", "Web開発"]

--- a/src/pages/posts/first-development-journey.md
+++ b/src/pages/posts/first-development-journey.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'Engineer Journey ブログサイト開発記録'
-pubDate: 2025-06-27
+pubDate: 2025-06-27T15:00:00
 description: 'Astroを使用したブログサイトの開発プロセスと学んだことをまとめた最初の投稿'
 author: 'Jun'
 tags: ["astro", "typescript", "cloudflare-pages", "web-development"]

--- a/src/pages/posts/github-actions-debugging-journey.md
+++ b/src/pages/posts/github-actions-debugging-journey.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'GitHub Actions デバッグ記録：権限エラーから完全動作まで'
-pubDate: 2025-06-28
+pubDate: 2025-06-28T16:00:00
 description: 'PR制御ワークフローが動かない原因を特定し、段階的に修正して完全動作させるまでの実践記録'
 author: 'jun-kb'
 tags: ["GitHub Actions", "デバッグ", "トラブルシューティング", "CI/CD", "権限"]

--- a/src/pages/posts/github-actions-workflow-optimization.md
+++ b/src/pages/posts/github-actions-workflow-optimization.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'GitHub Actions ワークフロー最適化：冗長なコードを削ぎ落とす'
-pubDate: 2025-06-28
+pubDate: 2025-06-28T15:00:00
 description: 'PR制御ボットのワークフローを43行から19行に最適化した実践記録'
 author: 'jun-kb'
 tags: ["GitHub Actions", "DevOps", "自動化", "最適化", "ワークフロー"]

--- a/src/pages/posts/minimal-design-philosophy.md
+++ b/src/pages/posts/minimal-design-philosophy.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'コンテンツが主役のミニマルデザイン：読書体験を重視したブログ刷新記録'
-pubDate: 2025-06-28
+pubDate: 2025-06-28T17:00:00
 description: '「読者が記事に集中できる」ことを最優先に、ブログサイトをモダンなミニマルデザインに刷新。SVGアイコン削除、モノクロ色彩、65ch幅制限など、コンテンツファースト設計の実装プロセス'
 author: 'Engineer Journey'
 tags: ["デザイン", "ミニマル", "UX", "タイポグラフィ", "CSS", "Astro"]

--- a/src/pages/posts/mobile-responsive-design-implementation.md
+++ b/src/pages/posts/mobile-responsive-design-implementation.md
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: 'スマホ対応でミニマルデザインを洗練：レスポンシブWebデザインの実践'
-pubDate: 2025-06-28
+pubDate: 2025-06-28T19:00:00
 description: 'スマホでの文字サイズと余白問題を解決し、ミニマルデザイン思想に沿ったレスポンシブ対応を実装。フルードタイポグラフィと適切なブレークポイント設計で読みやすさを向上。'
 author: 'jun-kb'
 tags: ["Responsive Design", "Mobile UX", "Minimal Design", "Typography", "CSS"]


### PR DESCRIPTION
## Summary
- トップページで最新記事が一番上に表示されない問題を修正
- 全ブログ投稿のpubDateに時刻情報を追加してISO 8601形式に統一

## 問題
同じ日付（2025-06-28）の記事が複数あり、最新記事がトップページで期待通りの順序で表示されていなかった。

## 解決策
全記事のpubDateを時刻込みの形式に変更し、正確な時系列順序を実現。

## 修正内容
以下の順序で時刻を設定（新しい順）:
- **mobile-responsive-design-implementation.md**: 2025-06-28T19:00:00 (最新)
- **minimal-design-philosophy.md**: 2025-06-28T17:00:00
- **github-actions-debugging-journey.md**: 2025-06-28T16:00:00
- **github-actions-workflow-optimization.md**: 2025-06-28T15:00:00
- **astro-dynamic-features.md**: 2025-06-27T17:00:00
- **first-development-journey.md**: 2025-06-27T15:00:00

## 効果
- トップページの動的ブログリストで最新記事が確実に一番上に表示
- 既存のソート機能（`new Date().getTime()` 比較）が正しく動作
- ISO 8601準拠でより標準的な日付形式

## Test plan
- [x] npm run build でエラーなし
- [x] 全記事ページが正常生成
- [x] Playwrightでトップページの順序確認
- [x] 最新記事が一番上に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)